### PR TITLE
add fish and fish-common packages to fix installation error

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,6 +6,8 @@
   with_items:
     - nodejs
     - build-essential
+    - fish
+    - fish-common
   tags:
     - nodejs
 


### PR DESCRIPTION
TASK [telusdigital.nodejs : Install Packages | apt] ****************************
failed: [localhost] (item=[u'nodejs', u'build-essential']) => {"cache_update_time": 1480699904, "cache_updated": false, "failed": true, "item": ["nodejs", "build-essential"], "msg": "'/usr/bin\
/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'nodejs'' failed: E: Unmet dependencies. Try 'apt-get -f install' with no packages (or spe\
cify a solution).\n", "stderr": "E: Unmet dependencies. Try 'apt-get -f install' with no packages (or specify a solution).\n", "stdout": "Reading package lists...\nBuilding dependency tree...\\
nReading state information...\nYou might want to run 'apt-get -f install' to correct these:\nThe following packages have unmet dependencies:\n fish : Depends: fish-common (= 2.4.0-2~trusty) bu\
t it is not going to be installed\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "You might want to run 'apt-get -f install' to\
 correct these:", "The following packages have unmet dependencies:", " fish : Depends: fish-common (= 2.4.0-2~trusty) but it is not going to be installed"]}